### PR TITLE
fix(nft-crypto): fix transaction builder pattern

### DIFF
--- a/packages/nft-base-crypto/__tests__/unit/builders/nft-burn.test.ts
+++ b/packages/nft-base-crypto/__tests__/unit/builders/nft-burn.test.ts
@@ -24,6 +24,19 @@ describe("NFT Burn tests", () => {
             expect(actual.verify()).toBeTrue();
         });
 
+        it("should verify correctly when Asset method is not on top", () => {
+            const actual = new NFTBurnBuilder()
+                .vendorField("nft-burn transaction")
+                .nonce("4")
+                .NFTBurnAsset({
+                    nftId: "5fe521beb05636fbe16d2eb628d835e6eb635070de98c3980c9ea9ea4496061a",
+                })
+                .sign("clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire");
+
+            expect(actual.build().verified).toBeTrue();
+            expect(actual.verify()).toBeTrue();
+        });
+
         it("object should remain the same if asset is undefined", () => {
             const actual = new NFTBurnBuilder();
             actual.data.asset = undefined;

--- a/packages/nft-base-crypto/__tests__/unit/builders/nft-create.test.ts
+++ b/packages/nft-base-crypto/__tests__/unit/builders/nft-create.test.ts
@@ -28,6 +28,22 @@ describe("NFT Create tests", () => {
             expect(actual.verify()).toBeTrue();
         });
 
+        it("should verify correctly when Asset method is not on top", () => {
+            const actual = new NFTCreateBuilder()
+                .nonce("4")
+                .NFTCreateToken({
+                    collectionId: "5fe521beb05636fbe16d2eb628d835e6eb635070de98c3980c9ea9ea4496061a",
+                    attributes: {
+                        number: 5,
+                        string: "something",
+                    },
+                })
+                .sign("clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire");
+
+            expect(actual.build().verified).toBeTrue();
+            expect(actual.verify()).toBeTrue();
+        });
+
         it("should not verify correctly, because byte size is to big", () => {
             defaults.nftTokenAttributesByteSize = 1;
             Transactions.TransactionRegistry.deregisterTransactionType(NFTCreateTransaction);

--- a/packages/nft-base-crypto/__tests__/unit/builders/nft-register-collection.test.ts
+++ b/packages/nft-base-crypto/__tests__/unit/builders/nft-register-collection.test.ts
@@ -37,6 +37,29 @@ describe("NFT Register Collection tests", () => {
             expect(actual.build().verified).toBeTrue();
             expect(actual.verify()).toBeTrue();
         });
+
+        it("should verify correctly when Asset method is not on top", () => {
+            const actual = new NFTRegisterCollectionBuilder()
+                .nonce("3")
+                .NFTRegisterCollectionAsset({
+                    name: "Heartstone card",
+                    description: "A card from heartstone game",
+                    maximumSupply: 100,
+                    jsonSchema: {
+                        properties: {
+                            number: {
+                                type: "number",
+                            },
+                            string: { type: "string" },
+                        },
+                    },
+                })
+                .sign("clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire");
+
+            expect(actual.build().verified).toBeTrue();
+            expect(actual.verify()).toBeTrue();
+        });
+
         it("should not verify correctly, because byte size is to big", () => {
             Transactions.TransactionRegistry.deregisterTransactionType(NFTRegisterCollectionTransaction);
             defaults.nftCollectionJsonSchemaByteSize = 1;

--- a/packages/nft-base-crypto/__tests__/unit/builders/nft-transfer.test.ts
+++ b/packages/nft-base-crypto/__tests__/unit/builders/nft-transfer.test.ts
@@ -21,7 +21,19 @@ describe("NFT Transfer tests", () => {
                 .nonce("5")
                 .sign("clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire");
 
-            console.log(JSON.stringify(actual.build().toJson()));
+            expect(actual.build().verified).toBeTrue();
+            expect(actual.verify()).toBeTrue();
+        });
+
+        it("should verify correctly when Asset method is not on top", () => {
+            const actual = new NFTTransferBuilder()
+                .nonce("5")
+                .NFTTransferAsset({
+                    nftIds: ["dfa8cbc8bba806348ebf112a4a01583ab869cccf72b72f7f3d28af9ff902d06d"],
+                    recipientId: Identities.Address.fromPassphrase(passphrases[1]!),
+                })
+                .sign("clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire");
+
             expect(actual.build().verified).toBeTrue();
             expect(actual.verify()).toBeTrue();
         });

--- a/packages/nft-base-crypto/src/builders/nft-base-builder.ts
+++ b/packages/nft-base-crypto/src/builders/nft-base-builder.ts
@@ -2,9 +2,9 @@ import { Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
 
 import { NFTBaseTransactionGroup, NFTBaseTransactionVersion } from "../enums";
 
-export abstract class NFTBaseTransactionBuilder<TBuilder> extends Transactions.TransactionBuilder<
-    NFTBaseTransactionBuilder<TBuilder>
-> {
+export abstract class NFTBaseTransactionBuilder<
+    TBuilder extends Transactions.TransactionBuilder<TBuilder>
+> extends Transactions.TransactionBuilder<TBuilder> {
     protected constructor() {
         super();
         this.data.version = NFTBaseTransactionVersion;

--- a/packages/nft-exchange-crypto/__tests__/unit/builders/nft-accept-trade.test.ts
+++ b/packages/nft-exchange-crypto/__tests__/unit/builders/nft-accept-trade.test.ts
@@ -24,6 +24,19 @@ describe("NFT Accept trade tests", () => {
             expect(actual.verify()).toBeTrue();
         });
 
+        it("should verify correctly when Asset method is not on top", () => {
+            const actual = new NftAcceptTradeBuilder()
+                .nonce("5")
+                .NFTAcceptTradeAsset({
+                    auctionId: "dfa8cbc8bba806348ebf112a4a01583ab869cccf72b72f7f3d28af9ff902d06d",
+                    bidId: "dfa8cbc8bba806348ebf112a4a01583ab869cccf72b72f7f3d28af9ff902d06d",
+                })
+                .sign("clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire");
+
+            expect(actual.build().verified).toBeTrue();
+            expect(actual.verify()).toBeTrue();
+        });
+
         it("object should remain the same if asset is undefined", () => {
             const actual = new NftAcceptTradeBuilder();
             actual.data.asset = undefined;

--- a/packages/nft-exchange-crypto/__tests__/unit/builders/nft-auction-cancel.test.ts
+++ b/packages/nft-exchange-crypto/__tests__/unit/builders/nft-auction-cancel.test.ts
@@ -23,6 +23,18 @@ describe("NFT Auction Cancel tests", () => {
             expect(actual.verify()).toBeTrue();
         });
 
+        it("should verify correctly when Asset method is not on top", () => {
+            const actual = new NFTAuctionCancelBuilder()
+                .nonce("5")
+                .NFTAuctionCancelAsset({
+                    auctionId: "dfa8cbc8bba806348ebf112a4a01583ab869cccf72b72f7f3d28af9ff902d06d",
+                })
+                .sign("clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire");
+
+            expect(actual.build().verified).toBeTrue();
+            expect(actual.verify()).toBeTrue();
+        });
+
         it("object should remain the same if asset is undefined", () => {
             const actual = new NFTAuctionCancelBuilder();
             actual.data.asset = undefined;

--- a/packages/nft-exchange-crypto/__tests__/unit/builders/nft-auction.test.ts
+++ b/packages/nft-exchange-crypto/__tests__/unit/builders/nft-auction.test.ts
@@ -27,6 +27,22 @@ describe("NFT Auction tests", () => {
             expect(actual.verify()).toBeTrue();
         });
 
+        it("should verify correctly when Asset method is not on top", () => {
+            const actual = new NFTAuctionBuilder()
+                .nonce("5")
+                .NFTAuctionAsset({
+                    nftIds: ["dfa8cbc8bba806348ebf112a4a01583ab869cccf72b72f7f3d28af9ff902d06d"],
+                    startAmount: Utils.BigNumber.make("1"),
+                    expiration: {
+                        blockHeight: 1,
+                    },
+                })
+                .sign("clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire");
+
+            expect(actual.build().verified).toBeTrue();
+            expect(actual.verify()).toBeTrue();
+        });
+
         it("object should remain the same if asset is undefined", () => {
             const actual = new NFTAuctionBuilder();
             actual.data.asset = undefined;

--- a/packages/nft-exchange-crypto/__tests__/unit/builders/nft-bid-cancel.test.ts
+++ b/packages/nft-exchange-crypto/__tests__/unit/builders/nft-bid-cancel.test.ts
@@ -23,6 +23,18 @@ describe("NFT Bid Cancel tests", () => {
             expect(actual.verify()).toBeTrue();
         });
 
+        it("should verify correctly when Asset method is not on top", () => {
+            const actual = new NFTBidCancelBuilder()
+                .nonce("5")
+                .NFTBidCancelAsset({
+                    bidId: "dfa8cbc8bba806348ebf112a4a01583ab869cccf72b72f7f3d28af9ff902d06d",
+                })
+                .sign("clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire");
+
+            expect(actual.build().verified).toBeTrue();
+            expect(actual.verify()).toBeTrue();
+        });
+
         it("object should remain the same if asset is undefined", () => {
             const actual = new NFTBidCancelBuilder();
             actual.data.asset = undefined;

--- a/packages/nft-exchange-crypto/__tests__/unit/builders/nft-bid.test.ts
+++ b/packages/nft-exchange-crypto/__tests__/unit/builders/nft-bid.test.ts
@@ -24,6 +24,19 @@ describe("NFT Bid tests", () => {
             expect(actual.verify()).toBeTrue();
         });
 
+        it("should verify correctly when Asset method is not on top", () => {
+            const actual = new NFTBidBuilder()
+                .nonce("5")
+                .NFTBidAsset({
+                    auctionId: "dfa8cbc8bba806348ebf112a4a01583ab869cccf72b72f7f3d28af9ff902d06d",
+                    bidAmount: Utils.BigNumber.make("1"),
+                })
+                .sign("clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire");
+
+            expect(actual.build().verified).toBeTrue();
+            expect(actual.verify()).toBeTrue();
+        });
+
         it("object should remain the same if asset is undefined", () => {
             const actual = new NFTBidBuilder();
             actual.data.asset = undefined;

--- a/packages/nft-exchange-crypto/src/builders/nft-exchange-builder.ts
+++ b/packages/nft-exchange-crypto/src/builders/nft-exchange-builder.ts
@@ -1,11 +1,10 @@
 import { Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
-import { TransactionBuilder } from "@arkecosystem/crypto/dist/transactions";
 
 import { NFTExchangeTransactionsTypeGroup, NFTExchangeTransactionVersion } from "../enums";
 
 export abstract class NFTExchangeTransactionBuilder<
-    TBuilder extends TransactionBuilder<TBuilder>
-> extends TransactionBuilder<TBuilder> {
+    TBuilder extends Transactions.TransactionBuilder<TBuilder>
+> extends Transactions.TransactionBuilder<TBuilder> {
     protected constructor() {
         super();
         this.data.version = NFTExchangeTransactionVersion;

--- a/packages/nft-exchange-crypto/src/builders/nft-exchange-builder.ts
+++ b/packages/nft-exchange-crypto/src/builders/nft-exchange-builder.ts
@@ -1,10 +1,11 @@
 import { Interfaces, Transactions, Utils } from "@arkecosystem/crypto";
+import { TransactionBuilder } from "@arkecosystem/crypto/dist/transactions";
 
 import { NFTExchangeTransactionsTypeGroup, NFTExchangeTransactionVersion } from "../enums";
 
-export abstract class NFTExchangeTransactionBuilder<TBuilder> extends Transactions.TransactionBuilder<
-    NFTExchangeTransactionBuilder<TBuilder>
-> {
+export abstract class NFTExchangeTransactionBuilder<
+    TBuilder extends TransactionBuilder<TBuilder>
+> extends TransactionBuilder<TBuilder> {
     protected constructor() {
         super();
         this.data.version = NFTExchangeTransactionVersion;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
This PR fixes transaction builder pattern.

### What changes are being made?
I changed that extended generic is of type abstract builder not abstract nft builder.

### Why are these changes necessary?
``` ts          
 const actual = new NFTBurnBuilder()
                .vendorField("nft-burn transaction")
                .nonce("4")
                .NFTBurnAsset({
                    nftId: "5fe521beb05636fbe16d2eb628d835e6eb635070de98c3980c9ea9ea4496061a",
                })
                .sign("clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire");
```
Make it possible to use asset method anywhere you want before build or sign.
<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

