### PR TITLE
fix: vendor field in transactions

### DIFF
--- a/.github/workflows/nft-base-functional.yml
+++ b/.github/workflows/nft-base-functional.yml
@@ -121,7 +121,7 @@ jobs:
         run: cd packages/nft-base-transactions && yarn test __tests__/functional/transaction-forging/nft-burn/multi-signature.test.ts --forceExit
 
   functional-base-transactions-burn-vendor-field:
-    name: NFT-BURN-SINGLE-PASSPHRASE
+    name: NFT-BURN-VENDOR-FIELD
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -275,7 +275,7 @@ jobs:
           yarn test __tests__/functional/transaction-forging/nft-create/multi-signature.test.ts --forceExit
 
   functional-base-transactions-create-vendor-field:
-    name: NFT-CREATE-SINGLE-PASSPHRASE
+    name: NFT-CREATE-VENDOR-FIELD
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -431,7 +431,7 @@ jobs:
           yarn test __tests__/functional/transaction-forging/nft-register-collection/multi-signature.test.ts --forceExit
 
   functional-base-transactions-register-vendor-field:
-    name: NFT-REGISTER-COLLECTION-SINGLE-PASSPHRASE
+    name: NFT-REGISTER-COLLECTION-VENDOR-FIELD
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -587,7 +587,7 @@ jobs:
           yarn test __tests__/functional/transaction-forging/nft-transfer/multi-signature.test.ts --forceExit
 
   functional-base-transactions-transfer-vendor-field:
-    name: NFT-TRANSFER-SINGLE-PASSPHRASE
+    name: NFT-TRANSFER-VENDOR-FIELD
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/nft-base-functional.yml
+++ b/.github/workflows/nft-base-functional.yml
@@ -120,6 +120,42 @@ jobs:
       - name: TEST
         run: cd packages/nft-base-transactions && yarn test __tests__/functional/transaction-forging/nft-burn/multi-signature.test.ts --forceExit
 
+  functional-base-transactions-burn-vendor-field:
+    name: NFT-BURN-SINGLE-PASSPHRASE
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: ark
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: ark_unitnet
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    strategy:
+      matrix:
+        node-version: [ 12.x ]
+    env:
+      CORE_DB_DATABASE: ark_unitnet
+      CORE_DB_USERNAME: ark
+      POSTGRES_USER: ark
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: ark_unitnet
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install and build packages
+        run: yarn && yarn build
+
+      - name: TEST
+        run: cd packages/nft-base-transactions && yarn test __tests__/functional/transaction-forging/nft-burn/vendor-field.test.ts --forceExit
 
   functional-base-transactions-create-single-passphrase:
     name: NFT-CREATE-SINGLE-PASSPHRASE

--- a/.github/workflows/nft-base-functional.yml
+++ b/.github/workflows/nft-base-functional.yml
@@ -585,3 +585,42 @@ jobs:
         run: |
           cd packages/nft-base-transactions
           yarn test __tests__/functional/transaction-forging/nft-transfer/multi-signature.test.ts --forceExit
+
+  functional-base-transactions-transfer-vendor-field:
+    name: NFT-TRANSFER-SINGLE-PASSPHRASE
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: ark
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: ark_unitnet
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    strategy:
+      matrix:
+        node-version: [ 12.x ]
+    env:
+      CORE_DB_DATABASE: ark_unitnet
+      CORE_DB_USERNAME: ark
+      POSTGRES_USER: ark
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: ark_unitnet
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install and build packages
+        run: yarn && yarn build
+
+      - name: TEST
+        run: |
+          cd packages/nft-base-transactions
+          yarn test __tests__/functional/transaction-forging/nft-transfer/vendor-field.test.ts --forceExit

--- a/.github/workflows/nft-base-functional.yml
+++ b/.github/workflows/nft-base-functional.yml
@@ -355,6 +355,45 @@ jobs:
           cd packages/nft-base-transactions
           yarn test __tests__/functional/transaction-forging/nft-register-collection/multi-signature.test.ts --forceExit
 
+  functional-base-transactions-register-vendor-field:
+    name: NFT-REGISTER-COLLECTION-SINGLE-PASSPHRASE
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: ark
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: ark_unitnet
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    strategy:
+      matrix:
+        node-version: [ 12.x ]
+    env:
+      CORE_DB_DATABASE: ark_unitnet
+      CORE_DB_USERNAME: ark
+      POSTGRES_USER: ark
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: ark_unitnet
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install and build packages
+        run: yarn && yarn build
+
+      - name: TEST
+        run: |
+          cd packages/nft-base-transactions
+          yarn test __tests__/functional/transaction-forging/nft-register-collection/vendor-field.test.ts --forceExit
+
   functional-base-transactions-transfer-single-passphrase:
     name: NFT-TRANSFER-SINGLE-PASSPHRASE
     runs-on: ubuntu-latest

--- a/.github/workflows/nft-base-functional.yml
+++ b/.github/workflows/nft-base-functional.yml
@@ -238,6 +238,45 @@ jobs:
           cd packages/nft-base-transactions
           yarn test __tests__/functional/transaction-forging/nft-create/multi-signature.test.ts --forceExit
 
+  functional-base-transactions-create-vendor-field:
+    name: NFT-CREATE-SINGLE-PASSPHRASE
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: ark
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: ark_unitnet
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    strategy:
+      matrix:
+        node-version: [ 12.x ]
+    env:
+      CORE_DB_DATABASE: ark_unitnet
+      CORE_DB_USERNAME: ark
+      POSTGRES_USER: ark
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: ark_unitnet
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install and build packages
+        run: yarn && yarn build
+
+      - name: TEST
+        run: |
+          cd packages/nft-base-transactions
+          yarn test __tests__/functional/transaction-forging/nft-create/vendor-field.test.ts --forceExit
+
   functional-base-transactions-register-single-passphrase:
     name: NFT-REGISTER-COLLECTION-SINGLE-PASSPHRASE
     runs-on: ubuntu-latest

--- a/.github/workflows/nft-exchange-functional.yml
+++ b/.github/workflows/nft-exchange-functional.yml
@@ -166,6 +166,44 @@ jobs:
           cd packages/nft-exchange-transactions
           yarn test __tests__/functional/transaction-forging/nft-auction/single-passphrase.test.ts --forceExit
 
+  functional-exchange-transactions-auction-vendor-field:
+    name: NFT-AUCTION-VENDOR-FIELD
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: ark
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: ark_unitnet
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    strategy:
+      matrix:
+        node-version: [ 12.x ]
+    env:
+      CORE_DB_DATABASE: ark_unitnet
+      CORE_DB_USERNAME: ark
+      POSTGRES_USER: ark
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: ark_unitnet
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install and build packages
+        run: yarn && yarn build
+
+      - name: TEST
+        run: |
+          cd packages/nft-exchange-transactions
+          yarn test __tests__/functional/transaction-forging/nft-auction/vendor-field.test.ts --forceExit
 
   functional-exchange-transactions-auction-second-passphrase:
     name: NFT-AUCTION-SECOND-PASSPHRASE

--- a/.github/workflows/nft-exchange-functional.yml
+++ b/.github/workflows/nft-exchange-functional.yml
@@ -403,6 +403,44 @@ jobs:
           cd packages/nft-exchange-transactions
           yarn test __tests__/functional/transaction-forging/nft-auction-cancel/multi-signature.test.ts --forceExit
 
+  functional-exchange-transactions-auction-cancel-vendor-field:
+    name: NFT-AUCTION-CANCEL-VENDOR-FIELD
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: ark
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: ark_unitnet
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    strategy:
+      matrix:
+        node-version: [ 12.x ]
+    env:
+      CORE_DB_DATABASE: ark_unitnet
+      CORE_DB_USERNAME: ark
+      POSTGRES_USER: ark
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: ark_unitnet
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install and build packages
+        run: yarn && yarn build
+
+      - name: TEST
+        run: |
+          cd packages/nft-exchange-transactions
+          yarn test __tests__/functional/transaction-forging/nft-auction-cancel/vendor-field.test.ts --forceExit
 
   functional-exchange-transactions-bid-single-passphrase:
     name: NFT-BID-SINGLE-PASSPHRASE

--- a/.github/workflows/nft-exchange-functional.yml
+++ b/.github/workflows/nft-exchange-functional.yml
@@ -717,3 +717,42 @@ jobs:
         run: |
           cd packages/nft-exchange-transactions
           yarn test __tests__/functional/transaction-forging/nft-bid-cancel/multi-signature.test.ts --forceExit
+
+  functional-exchange-transactions-bid-cancel-vendor-field:
+    name: NFT-BID-CANCEL-VENDOR-FIELD
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: ark
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: ark_unitnet
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    strategy:
+      matrix:
+        node-version: [ 12.x ]
+    env:
+      CORE_DB_DATABASE: ark_unitnet
+      CORE_DB_USERNAME: ark
+      POSTGRES_USER: ark
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: ark_unitnet
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install and build packages
+        run: yarn && yarn build
+
+      - name: TEST
+        run: |
+          cd packages/nft-exchange-transactions
+          yarn test __tests__/functional/transaction-forging/nft-bid-cancel/vendor-field.test.ts --forceExit

--- a/.github/workflows/nft-exchange-functional.yml
+++ b/.github/workflows/nft-exchange-functional.yml
@@ -126,6 +126,44 @@ jobs:
           cd packages/nft-exchange-transactions
           yarn test __tests__/functional/transaction-forging/nft-accept-trade/multi-signature.test.ts --forceExit
 
+  functional-exchange-transactions-accept-trade-vendor-field:
+    name: NFT-ACCEPT-TRADE-VENDOR-FIELD
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: ark
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: ark_unitnet
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    strategy:
+      matrix:
+        node-version: [ 12.x ]
+    env:
+      CORE_DB_DATABASE: ark_unitnet
+      CORE_DB_USERNAME: ark
+      POSTGRES_USER: ark
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: ark_unitnet
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install and build packages
+        run: yarn && yarn build
+
+      - name: TEST
+        run: |
+          cd packages/nft-exchange-transactions
+          yarn test __tests__/functional/transaction-forging/nft-accept-trade/vendor-field.test.ts --forceExit
 
   functional-exchange-transactions-auction-single-passphrase:
     name: NFT-AUCTION-SINGLE-PASSPHRASE

--- a/.github/workflows/nft-exchange-functional.yml
+++ b/.github/workflows/nft-exchange-functional.yml
@@ -561,6 +561,44 @@ jobs:
           cd packages/nft-exchange-transactions
           yarn test __tests__/functional/transaction-forging/nft-bid/multi-signature.test.ts --forceExit
 
+  functional-exchange-transactions-bid-vendor-field:
+    name: NFT-BID-VENDOR-FIELD
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: ark
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: ark_unitnet
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    strategy:
+      matrix:
+        node-version: [ 12.x ]
+    env:
+      CORE_DB_DATABASE: ark_unitnet
+      CORE_DB_USERNAME: ark
+      POSTGRES_USER: ark
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: ark_unitnet
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install and build packages
+        run: yarn && yarn build
+
+      - name: TEST
+        run: |
+          cd packages/nft-exchange-transactions
+          yarn test __tests__/functional/transaction-forging/nft-bid/vendor-field.test.ts --forceExit
 
   functional-exchange-transactions-bid-cancel-single-passphrase:
     name: NFT-BID-CANCEL-SINGLE-PASSPHRASE

--- a/packages/nft-base-crypto/src/builders/nft-base-builder.ts
+++ b/packages/nft-base-crypto/src/builders/nft-base-builder.ts
@@ -16,6 +16,7 @@ export abstract class NFTBaseTransactionBuilder<
         const struct: Interfaces.ITransactionData = super.getStruct();
         struct.amount = this.data.amount;
         struct.asset = this.data.asset;
+        struct.vendorField = this.data.vendorField;
         return struct;
     }
 }

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/__support__/index.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/__support__/index.ts
@@ -41,6 +41,7 @@ export const setUp = async (): Promise<Contracts.Kernel.Application> => {
 
         Managers.configManager.getMilestone().aip11 = true;
         Managers.configManager.getMilestone().htlcEnabled = true;
+        Managers.configManager.getMilestone().vendorFieldLength = 255;
 
         const databaseService = app.get<DatabaseService>(Container.Identifiers.DatabaseService);
         const walletRepository = app.getTagged<Contracts.State.WalletRepository>(

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/__support__/transaction-factory.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/__support__/transaction-factory.ts
@@ -11,6 +11,11 @@ export class NFTBaseTransactionFactory extends TransactionFactory {
         return new NFTBaseTransactionFactory(app);
     }
 
+    public withVendorField(vendorField: string): NFTBaseTransactionFactory {
+        this.builder.vendorField(vendorField);
+        return this;
+    }
+
     public NFTRegisterCollection(nftCollection: NFTInterfaces.NFTCollectionAsset): NFTBaseTransactionFactory {
         this.builder = new NFTBuilders.NFTRegisterCollectionBuilder().NFTRegisterCollectionAsset(nftCollection);
 

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-burn/vendor-field.test.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-burn/vendor-field.test.ts
@@ -14,7 +14,7 @@ beforeAll(async () => {
 
 afterAll(async () => await support.tearDown());
 
-describe("NFT Create functional tests - Signed with one Passphrase", () => {
+describe("NFT Burn functional tests - with VendorField", () => {
     it("should broadcast, accept and forge it [Signed with 1 Passphrase]", async () => {
         // Register collection
         const nftRegisteredCollection = NFTBaseTransactionFactory.initialize(app)

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-burn/vendor-field.test.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-burn/vendor-field.test.ts
@@ -1,0 +1,105 @@
+import "@arkecosystem/core-test-framework/dist/matchers";
+
+import { Contracts } from "@arkecosystem/core-kernel";
+import { passphrases, snoozeForBlock } from "@arkecosystem/core-test-framework";
+
+import * as support from "../__support__";
+import { NFTBaseTransactionFactory } from "../__support__/transaction-factory";
+
+let app: Contracts.Kernel.Application;
+
+beforeAll(async () => {
+    app = await support.setUp();
+});
+
+afterAll(async () => await support.tearDown());
+
+describe("NFT Create functional tests - Signed with one Passphrase", () => {
+    it("should broadcast, accept and forge it [Signed with 1 Passphrase]", async () => {
+        // Register collection
+        const nftRegisteredCollection = NFTBaseTransactionFactory.initialize(app)
+            .NFTRegisterCollection({
+                name: "Nascar Hero Cards",
+                description: "Nascar Hero Cards collection",
+                maximumSupply: 100,
+                jsonSchema: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["ipfsHashImageFront", "issuedDate", "issuedLocation", "signed"],
+                    properties: {
+                        ipfsHashImageFront: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        ipfsHashImageBack: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        issuedDate: {
+                            format: "date",
+                        },
+                        issuedLocation: {
+                            type: "string",
+                            maxLength: 255,
+                            minLength: 1,
+                        },
+                        signed: {
+                            type: "boolean",
+                        },
+                        tags: {
+                            type: "array",
+                            maxItems: 12,
+                            minItems: 1,
+                            additionalItems: false,
+                            uniqueItems: true,
+                            items: {
+                                type: "string",
+                            },
+                        },
+                    },
+                },
+            })
+            .withVendorField("VendorField test -> [NFTRegisterCollection]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftRegisteredCollection).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftRegisteredCollection.id).toBeForged();
+
+        // Create token
+        const nftCreate = NFTBaseTransactionFactory.initialize(app)
+            .NFTCreate({
+                collectionId: nftRegisteredCollection.id!,
+                attributes: {
+                    ipfsHashImageFront: "QmavUFtLyRbUEEFLrmDTyRY5sLMh8UnQxWEenx2tuvzSE6",
+                    ipfsHashImageBack: "QmdGCntrw9yabGJAU1nG3H38yQ2GLsphg3jwaxSGbXEj61",
+                    issuedDate: "2020-09-25",
+                    issuedLocation: "Mooresville , North Carolina",
+                    signed: true,
+                },
+            })
+            .withVendorField("VendorField test -> [NFTCreate]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftCreate).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftCreate.id).toBeForged();
+
+        // Burn token
+        const nftBurn = NFTBaseTransactionFactory.initialize(app)
+            .NFTBurn({
+                nftId: nftCreate.id!,
+            })
+            .withVendorField("VendorField test -> [NFTBurn]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftBurn).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftBurn.id).toBeForged();
+    });
+});

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-create/vendor-field.test.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-create/vendor-field.test.ts
@@ -2,7 +2,6 @@ import "@arkecosystem/core-test-framework/dist/matchers";
 
 import { Contracts } from "@arkecosystem/core-kernel";
 import { passphrases, snoozeForBlock } from "@arkecosystem/core-test-framework";
-import { Identities } from "@arkecosystem/crypto";
 
 import * as support from "../__support__";
 import { NFTBaseTransactionFactory } from "../__support__/transaction-factory";

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-create/vendor-field.test.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-create/vendor-field.test.ts
@@ -14,7 +14,7 @@ beforeAll(async () => {
 
 afterAll(async () => await support.tearDown());
 
-describe("NFT Create functional tests - Signed with one Passphrase", () => {
+describe("NFT Create functional tests - with VendorField", () => {
     it("should broadcast, accept and forge it [Signed with 1 Passphrase]", async () => {
         // Register collection
         const nftRegisteredCollection = NFTBaseTransactionFactory.initialize(app)

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-create/vendor-field.test.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-create/vendor-field.test.ts
@@ -1,0 +1,93 @@
+import "@arkecosystem/core-test-framework/dist/matchers";
+
+import { Contracts } from "@arkecosystem/core-kernel";
+import { passphrases, snoozeForBlock } from "@arkecosystem/core-test-framework";
+import { Identities } from "@arkecosystem/crypto";
+
+import * as support from "../__support__";
+import { NFTBaseTransactionFactory } from "../__support__/transaction-factory";
+
+let app: Contracts.Kernel.Application;
+
+beforeAll(async () => {
+    app = await support.setUp();
+});
+
+afterAll(async () => await support.tearDown());
+
+describe("NFT Create functional tests - Signed with one Passphrase", () => {
+    it("should broadcast, accept and forge it [Signed with 1 Passphrase]", async () => {
+        // Register collection
+        const nftRegisteredCollection = NFTBaseTransactionFactory.initialize(app)
+            .NFTRegisterCollection({
+                name: "Nascar Hero Cards",
+                description: "Nascar Hero Cards collection",
+                maximumSupply: 100,
+                jsonSchema: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["ipfsHashImageFront", "issuedDate", "issuedLocation", "signed"],
+                    properties: {
+                        ipfsHashImageFront: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        ipfsHashImageBack: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        issuedDate: {
+                            format: "date",
+                        },
+                        issuedLocation: {
+                            type: "string",
+                            maxLength: 255,
+                            minLength: 1,
+                        },
+                        signed: {
+                            type: "boolean",
+                        },
+                        tags: {
+                            type: "array",
+                            maxItems: 12,
+                            minItems: 1,
+                            additionalItems: false,
+                            uniqueItems: true,
+                            items: {
+                                type: "string",
+                            },
+                        },
+                    },
+                },
+            })
+            .withVendorField("VendorField test -> [NFTRegisterCollection]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftRegisteredCollection).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftRegisteredCollection.id).toBeForged();
+
+        // Create token
+        const nftCreate = NFTBaseTransactionFactory.initialize(app)
+            .NFTCreate({
+                collectionId: nftRegisteredCollection.id!,
+                attributes: {
+                    ipfsHashImageFront: "QmavUFtLyRbUEEFLrmDTyRY5sLMh8UnQxWEenx2tuvzSE6",
+                    ipfsHashImageBack: "QmdGCntrw9yabGJAU1nG3H38yQ2GLsphg3jwaxSGbXEj61",
+                    issuedDate: "2020-09-25",
+                    issuedLocation: "Mooresville , North Carolina",
+                    signed: true,
+                },
+            })
+            .withVendorField("VendorField test -> [NFTCreate]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftCreate).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftCreate.id).toBeForged();
+    });
+});

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-register-collection/vendor-field.test.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-register-collection/vendor-field.test.ts
@@ -1,0 +1,72 @@
+import "@arkecosystem/core-test-framework/dist/matchers";
+
+import { Contracts } from "@arkecosystem/core-kernel";
+import { passphrases, snoozeForBlock } from "@arkecosystem/core-test-framework";
+
+import * as support from "../__support__";
+import { NFTBaseTransactionFactory } from "../__support__/transaction-factory";
+
+let app: Contracts.Kernel.Application;
+
+beforeAll(async () => {
+    app = await support.setUp();
+});
+
+afterAll(async () => await support.tearDown());
+
+describe("NFT Register collection functional tests - with VendorField", () => {
+    it("should broadcast, accept and forge it [Signed with 1 Passphrase]", async () => {
+        // Register collection
+        const nftRegisteredCollection = NFTBaseTransactionFactory.initialize(app)
+            .NFTRegisterCollection({
+                name: "Nascar Hero Cards",
+                description: "Nascar Hero Cards collection",
+                maximumSupply: 100,
+                jsonSchema: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["ipfsHashImageFront", "issuedDate", "issuedLocation", "signed"],
+                    properties: {
+                        ipfsHashImageFront: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        ipfsHashImageBack: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        issuedDate: {
+                            format: "date",
+                        },
+                        issuedLocation: {
+                            type: "string",
+                            maxLength: 255,
+                            minLength: 1,
+                        },
+                        signed: {
+                            type: "boolean",
+                        },
+                        tags: {
+                            type: "array",
+                            maxItems: 12,
+                            minItems: 1,
+                            additionalItems: false,
+                            uniqueItems: true,
+                            items: {
+                                type: "string",
+                            },
+                        },
+                    },
+                },
+            })
+            .withVendorField("VendorField test -> [NFTRegisterCollection]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftRegisteredCollection).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftRegisteredCollection.id).toBeForged();
+    });
+});

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-transfer/vendor-field.test.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-transfer/vendor-field.test.ts
@@ -1,0 +1,107 @@
+import "@arkecosystem/core-test-framework/dist/matchers";
+
+import { Contracts } from "@arkecosystem/core-kernel";
+import { passphrases, snoozeForBlock } from "@arkecosystem/core-test-framework";
+import { Identities } from "@arkecosystem/crypto";
+
+import * as support from "../__support__";
+import { NFTBaseTransactionFactory } from "../__support__/transaction-factory";
+
+let app: Contracts.Kernel.Application;
+
+beforeAll(async () => {
+    app = await support.setUp();
+});
+
+afterAll(async () => await support.tearDown());
+
+describe("NFT Create functional tests - with VendorField", () => {
+    it("should broadcast, accept and forge it [Signed with 1 Passphrase]", async () => {
+        // Register collection
+        const nftRegisteredCollection = NFTBaseTransactionFactory.initialize(app)
+            .NFTRegisterCollection({
+                name: "Nascar Hero Cards",
+                description: "Nascar Hero Cards collection",
+                maximumSupply: 100,
+                jsonSchema: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["ipfsHashImageFront", "issuedDate", "issuedLocation", "signed"],
+                    properties: {
+                        ipfsHashImageFront: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        ipfsHashImageBack: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        issuedDate: {
+                            format: "date",
+                        },
+                        issuedLocation: {
+                            type: "string",
+                            maxLength: 255,
+                            minLength: 1,
+                        },
+                        signed: {
+                            type: "boolean",
+                        },
+                        tags: {
+                            type: "array",
+                            maxItems: 12,
+                            minItems: 1,
+                            additionalItems: false,
+                            uniqueItems: true,
+                            items: {
+                                type: "string",
+                            },
+                        },
+                    },
+                },
+            })
+            .withVendorField("VendorField test -> [NFTRegisterCollection]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftRegisteredCollection).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftRegisteredCollection.id).toBeForged();
+
+        // Create token
+        const nftCreate = NFTBaseTransactionFactory.initialize(app)
+            .NFTCreate({
+                collectionId: nftRegisteredCollection.id!,
+                attributes: {
+                    ipfsHashImageFront: "QmavUFtLyRbUEEFLrmDTyRY5sLMh8UnQxWEenx2tuvzSE6",
+                    ipfsHashImageBack: "QmdGCntrw9yabGJAU1nG3H38yQ2GLsphg3jwaxSGbXEj61",
+                    issuedDate: "2020-09-25",
+                    issuedLocation: "Mooresville , North Carolina",
+                    signed: true,
+                },
+            })
+            .withVendorField("VendorField test -> [NFTCreate]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftCreate).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftCreate.id).toBeForged();
+
+        // Transfer token
+        const nftTransfer = NFTBaseTransactionFactory.initialize(app)
+            .NFTTransfer({
+                nftIds: [nftCreate.id!],
+                recipientId: Identities.Address.fromPassphrase(passphrases[2]!),
+            })
+            .withVendorField("VendorField test -> [NFTTransfer]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftTransfer).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftTransfer.id).toBeForged();
+    });
+});

--- a/packages/nft-exchange-crypto/src/builders/nft-exchange-builder.ts
+++ b/packages/nft-exchange-crypto/src/builders/nft-exchange-builder.ts
@@ -16,6 +16,7 @@ export abstract class NFTExchangeTransactionBuilder<
         const struct: Interfaces.ITransactionData = super.getStruct();
         struct.amount = this.data.amount;
         struct.asset = this.data.asset;
+        struct.vendorField = this.data.vendorField;
         return struct;
     }
 }

--- a/packages/nft-exchange-crypto/src/transactions/nft-accept-trade.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-accept-trade.ts
@@ -28,6 +28,7 @@ export class NFTAcceptTradeTransaction extends Transactions.Transaction {
                 type: { transactionType: NFTTransactionTypes.NFTAcceptTrade },
                 typeGroup: { const: NFTExchangeTransactionsTypeGroup },
                 amount: { bignumber: { minimum: 0, maximum: 0 } },
+                vendorField: { anyOf: [{ type: "null" }, { type: "string", format: "vendorField" }] },
                 asset: {
                     type: "object",
                     required: ["nftAcceptTrade"],
@@ -74,5 +75,9 @@ export class NFTAcceptTradeTransaction extends Transactions.Transaction {
         data.asset = {
             nftAcceptTrade,
         };
+    }
+
+    public hasVendorField(): boolean {
+        return true;
     }
 }

--- a/packages/nft-exchange-crypto/src/transactions/nft-auction-cancel.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-auction-cancel.ts
@@ -28,6 +28,7 @@ export class NFTAuctionCancelTransaction extends Transactions.Transaction {
                 type: { transactionType: NFTTransactionTypes.NFTAuctionCancel },
                 typeGroup: { const: NFTExchangeTransactionsTypeGroup },
                 amount: { bignumber: { minimum: 0, maximum: 0 } },
+                vendorField: { anyOf: [{ type: "null" }, { type: "string", format: "vendorField" }] },
                 asset: {
                     type: "object",
                     required: ["nftAuctionCancel"],
@@ -68,5 +69,9 @@ export class NFTAuctionCancelTransaction extends Transactions.Transaction {
         data.asset = {
             nftAuctionCancel,
         };
+    }
+
+    public hasVendorField(): boolean {
+        return true;
     }
 }

--- a/packages/nft-exchange-crypto/src/transactions/nft-auction.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-auction.ts
@@ -106,4 +106,8 @@ export class NFTAuctionTransaction extends Transactions.Transaction {
             nftAuction,
         };
     }
+
+    public hasVendorField(): boolean {
+        return true;
+    }
 }

--- a/packages/nft-exchange-crypto/src/transactions/nft-auction.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-auction.ts
@@ -29,6 +29,7 @@ export class NFTAuctionTransaction extends Transactions.Transaction {
                 type: { transactionType: NFTTransactionTypes.NFTAuction },
                 typeGroup: { const: NFTExchangeTransactionsTypeGroup },
                 amount: { bignumber: { minimum: 0, maximum: 0 } },
+                vendorField: { anyOf: [{ type: "null" }, { type: "string", format: "vendorField" }] },
                 asset: {
                     type: "object",
                     required: ["nftAuction"],

--- a/packages/nft-exchange-crypto/src/transactions/nft-bid-cancel.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-bid-cancel.ts
@@ -28,6 +28,7 @@ export class NFTBidCancelTransaction extends Transactions.Transaction {
                 type: { transactionType: NFTTransactionTypes.NFTBidCancel },
                 typeGroup: { const: NFTExchangeTransactionsTypeGroup },
                 amount: { bignumber: { minimum: 0, maximum: 0 } },
+                vendorField: { anyOf: [{ type: "null" }, { type: "string", format: "vendorField" }] },
                 asset: {
                     type: "object",
                     required: ["nftBidCancel"],
@@ -68,5 +69,9 @@ export class NFTBidCancelTransaction extends Transactions.Transaction {
         data.asset = {
             nftBidCancel,
         };
+    }
+
+    public hasVendorField(): boolean {
+        return true;
     }
 }

--- a/packages/nft-exchange-crypto/src/transactions/nft-bid.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-bid.ts
@@ -28,6 +28,7 @@ export class NFTBidTransaction extends Transactions.Transaction {
                 type: { transactionType: NFTTransactionTypes.NFTBid },
                 typeGroup: { const: NFTExchangeTransactionsTypeGroup },
                 amount: { bignumber: { minimum: 0, maximum: 0 } },
+                vendorField: { anyOf: [{ type: "null" }, { type: "string", format: "vendorField" }] },
                 asset: {
                     type: "object",
                     required: ["nftBid"],
@@ -74,5 +75,9 @@ export class NFTBidTransaction extends Transactions.Transaction {
         data.asset = {
             nftBid,
         };
+    }
+
+    public hasVendorField(): boolean {
+        return true;
     }
 }

--- a/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/__support__/index.ts
+++ b/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/__support__/index.ts
@@ -41,6 +41,7 @@ export const setUp = async (): Promise<Contracts.Kernel.Application> => {
 
         Managers.configManager.getMilestone().aip11 = true;
         Managers.configManager.getMilestone().htlcEnabled = true;
+        Managers.configManager.getMilestone().vendorFieldLength = 255;
 
         const databaseService = app.get<DatabaseService>(Container.Identifiers.DatabaseService);
         const walletRepository = app.getTagged<Contracts.State.WalletRepository>(

--- a/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/__support__/transaction-factory.ts
+++ b/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/__support__/transaction-factory.ts
@@ -12,6 +12,11 @@ export class NFTExchangeTransactionFactory extends TransactionFactory {
         return new NFTExchangeTransactionFactory(app);
     }
 
+    public withVendorField(vendorField: string): NFTExchangeTransactionFactory {
+        this.builder.vendorField(vendorField);
+        return this;
+    }
+
     public NFTAuction(nftAuctionAsset: NFTExchangeInterfaces.NFTAuctionAsset): NFTExchangeTransactionFactory {
         this.builder = new NFTExchangeBuilders.NFTAuctionBuilder().NFTAuctionAsset(nftAuctionAsset);
 

--- a/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/nft-accept-trade/vendor-field.test.ts
+++ b/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/nft-accept-trade/vendor-field.test.ts
@@ -1,0 +1,134 @@
+import "@arkecosystem/core-test-framework/dist/matchers";
+
+import { Contracts } from "@arkecosystem/core-kernel";
+import { passphrases, snoozeForBlock } from "@arkecosystem/core-test-framework";
+import { Utils } from "@arkecosystem/crypto";
+
+import * as support from "../__support__";
+import { NFTExchangeTransactionFactory } from "../__support__/transaction-factory";
+
+let app: Contracts.Kernel.Application;
+beforeAll(async () => (app = await support.setUp()));
+afterAll(async () => await support.tearDown());
+
+describe("NFT Accept Trade functional tests - with VendorField", () => {
+    it("should broadcast, accept and forge it [Signed with 1 Passphrase]", async () => {
+        // Register collection
+        const nftRegisteredCollection = NFTExchangeTransactionFactory.initialize(app)
+            .NFTRegisterCollection({
+                name: "Nascar Hero Cards",
+                description: "Nascar Hero Cards collection",
+                maximumSupply: 100,
+                jsonSchema: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["ipfsHashImageFront", "issuedDate", "issuedLocation", "signed"],
+                    properties: {
+                        ipfsHashImageFront: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        ipfsHashImageBack: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        issuedDate: {
+                            format: "date",
+                        },
+                        issuedLocation: {
+                            type: "string",
+                            maxLength: 255,
+                            minLength: 1,
+                        },
+                        signed: {
+                            type: "boolean",
+                        },
+                        tags: {
+                            type: "array",
+                            maxItems: 12,
+                            minItems: 1,
+                            additionalItems: false,
+                            uniqueItems: true,
+                            items: {
+                                type: "string",
+                            },
+                        },
+                    },
+                },
+            })
+            .withVendorField("VendorField test -> [NFTRegisterCollection]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftRegisteredCollection).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftRegisteredCollection.id).toBeForged();
+
+        // Create token
+        const nftCreate = NFTExchangeTransactionFactory.initialize(app)
+            .NFTCreate({
+                collectionId: nftRegisteredCollection.id!,
+                attributes: {
+                    ipfsHashImageFront: "QmavUFtLyRbUEEFLrmDTyRY5sLMh8UnQxWEenx2tuvzSE6",
+                    ipfsHashImageBack: "QmdGCntrw9yabGJAU1nG3H38yQ2GLsphg3jwaxSGbXEj61",
+                    issuedDate: "2020-09-25",
+                    issuedLocation: "Mooresville , North Carolina",
+                    signed: true,
+                },
+            })
+            .withVendorField("VendorField test -> [NFTCreate]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftCreate).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftCreate.id).toBeForged();
+
+        // Create auction
+        const nftAuction = NFTExchangeTransactionFactory.initialize(app)
+            .NFTAuction({
+                expiration: {
+                    blockHeight: 30,
+                },
+                startAmount: Utils.BigNumber.make("1"),
+                nftIds: [nftCreate.id!],
+            })
+            .withVendorField("VendorField test -> [NFTAuction]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftAuction).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftAuction.id).toBeForged();
+
+        // Create bid
+        const nftBid = NFTExchangeTransactionFactory.initialize(app)
+            .NFTBid({
+                auctionId: nftAuction.id!,
+                bidAmount: Utils.BigNumber.make("2"),
+            })
+            .withVendorField("VendorField test -> [NFTBid]")
+            .withPassphrase(passphrases[1]!)
+            .createOne();
+
+        await expect(nftBid).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftBid.id).toBeForged();
+
+        // AcceptTrade
+        const nftAcceptTrade = NFTExchangeTransactionFactory.initialize(app)
+            .NFTAcceptTrade({
+                auctionId: nftAuction.id!,
+                bidId: nftBid.id!,
+            })
+            .withVendorField("VendorField test -> [NFTAcceptTrade]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftAcceptTrade).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftAcceptTrade.id).toBeForged();
+    });
+});

--- a/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/nft-auction-cancel/vendor-field.test.ts
+++ b/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/nft-auction-cancel/vendor-field.test.ts
@@ -1,0 +1,119 @@
+import "@arkecosystem/core-test-framework/dist/matchers";
+
+import { Contracts } from "@arkecosystem/core-kernel";
+import { passphrases, snoozeForBlock } from "@arkecosystem/core-test-framework";
+import { Utils } from "@arkecosystem/crypto";
+
+import * as support from "../__support__";
+import { NFTExchangeTransactionFactory } from "../__support__/transaction-factory";
+
+let app: Contracts.Kernel.Application;
+beforeAll(async () => (app = await support.setUp()));
+afterAll(async () => await support.tearDown());
+
+describe("NFT Auction Cancel functional tests - with VendorField", () => {
+    it("should broadcast, accept and forge it [Signed with 1 Passphrase]", async () => {
+        // Register collection
+        const nftRegisteredCollection = NFTExchangeTransactionFactory.initialize(app)
+            .NFTRegisterCollection({
+                name: "Nascar Hero Cards",
+                description: "Nascar Hero Cards collection",
+                maximumSupply: 100,
+                jsonSchema: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["ipfsHashImageFront", "issuedDate", "issuedLocation", "signed"],
+                    properties: {
+                        ipfsHashImageFront: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        ipfsHashImageBack: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        issuedDate: {
+                            format: "date",
+                        },
+                        issuedLocation: {
+                            type: "string",
+                            maxLength: 255,
+                            minLength: 1,
+                        },
+                        signed: {
+                            type: "boolean",
+                        },
+                        tags: {
+                            type: "array",
+                            maxItems: 12,
+                            minItems: 1,
+                            additionalItems: false,
+                            uniqueItems: true,
+                            items: {
+                                type: "string",
+                            },
+                        },
+                    },
+                },
+            })
+            .withVendorField("VendorField test -> [NFTRegisterCollection]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftRegisteredCollection).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftRegisteredCollection.id).toBeForged();
+
+        // Create token
+        const nftCreate = NFTExchangeTransactionFactory.initialize(app)
+            .NFTCreate({
+                collectionId: nftRegisteredCollection.id!,
+                attributes: {
+                    ipfsHashImageFront: "QmavUFtLyRbUEEFLrmDTyRY5sLMh8UnQxWEenx2tuvzSE6",
+                    ipfsHashImageBack: "QmdGCntrw9yabGJAU1nG3H38yQ2GLsphg3jwaxSGbXEj61",
+                    issuedDate: "2020-09-25",
+                    issuedLocation: "Mooresville , North Carolina",
+                    signed: true,
+                },
+            })
+            .withVendorField("VendorField test -> [NFTCreate]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftCreate).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftCreate.id).toBeForged();
+
+        // Create auction
+        const nftAuction = NFTExchangeTransactionFactory.initialize(app)
+            .NFTAuction({
+                expiration: {
+                    blockHeight: 30,
+                },
+                startAmount: Utils.BigNumber.make("1"),
+                nftIds: [nftCreate.id!],
+            })
+            .withVendorField("VendorField test -> [NFTAuction]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftAuction).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftAuction.id).toBeForged();
+
+        // Create cancel auction
+        const nftAuctionCancel = NFTExchangeTransactionFactory.initialize(app)
+            .NFTAuctionCancel({
+                auctionId: nftAuction.id!,
+            })
+            .withVendorField("VendorField test -> [NFTAuctionCancel]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftAuctionCancel).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftAuctionCancel.id).toBeForged();
+    });
+});

--- a/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/nft-auction/vendor-field.test.ts
+++ b/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/nft-auction/vendor-field.test.ts
@@ -1,0 +1,106 @@
+import "@arkecosystem/core-test-framework/dist/matchers";
+
+import { Contracts } from "@arkecosystem/core-kernel";
+import { passphrases, snoozeForBlock } from "@arkecosystem/core-test-framework";
+import { Utils } from "@arkecosystem/crypto";
+
+import * as support from "../__support__";
+import { NFTExchangeTransactionFactory } from "../__support__/transaction-factory";
+
+let app: Contracts.Kernel.Application;
+beforeAll(async () => (app = await support.setUp()));
+afterAll(async () => await support.tearDown());
+
+describe("NFT Auction functional tests - with VendorField", () => {
+    it("should broadcast, accept and forge it [Signed with 1 Passphrase]", async () => {
+        // Register collection
+        const nftRegisteredCollection = NFTExchangeTransactionFactory.initialize(app)
+            .NFTRegisterCollection({
+                name: "Nascar Hero Cards",
+                description: "Nascar Hero Cards collection",
+                maximumSupply: 100,
+                jsonSchema: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["ipfsHashImageFront", "issuedDate", "issuedLocation", "signed"],
+                    properties: {
+                        ipfsHashImageFront: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        ipfsHashImageBack: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        issuedDate: {
+                            format: "date",
+                        },
+                        issuedLocation: {
+                            type: "string",
+                            maxLength: 255,
+                            minLength: 1,
+                        },
+                        signed: {
+                            type: "boolean",
+                        },
+                        tags: {
+                            type: "array",
+                            maxItems: 12,
+                            minItems: 1,
+                            additionalItems: false,
+                            uniqueItems: true,
+                            items: {
+                                type: "string",
+                            },
+                        },
+                    },
+                },
+            })
+            .withVendorField("VendorField test -> [NFTRegisterCollection]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftRegisteredCollection).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftRegisteredCollection.id).toBeForged();
+
+        // Create token
+        const nftCreate = NFTExchangeTransactionFactory.initialize(app)
+            .NFTCreate({
+                collectionId: nftRegisteredCollection.id!,
+                attributes: {
+                    ipfsHashImageFront: "QmavUFtLyRbUEEFLrmDTyRY5sLMh8UnQxWEenx2tuvzSE6",
+                    ipfsHashImageBack: "QmdGCntrw9yabGJAU1nG3H38yQ2GLsphg3jwaxSGbXEj61",
+                    issuedDate: "2020-09-25",
+                    issuedLocation: "Mooresville , North Carolina",
+                    signed: true,
+                },
+            })
+            .withVendorField("VendorField test -> [NFTCreate]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftCreate).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftCreate.id).toBeForged();
+
+        // Create auction
+        const nftAuction = NFTExchangeTransactionFactory.initialize(app)
+            .NFTAuction({
+                expiration: {
+                    blockHeight: 30,
+                },
+                startAmount: Utils.BigNumber.make("1"),
+                nftIds: [nftCreate.id!],
+            })
+            .withVendorField("VendorField test -> [NFTAuction]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftAuction).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftAuction.id).toBeForged();
+    });
+});

--- a/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/nft-bid-cancel/vendor-field.test.ts
+++ b/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/nft-bid-cancel/vendor-field.test.ts
@@ -1,0 +1,133 @@
+import "@arkecosystem/core-test-framework/dist/matchers";
+
+import { Contracts } from "@arkecosystem/core-kernel";
+import { passphrases, snoozeForBlock } from "@arkecosystem/core-test-framework";
+import { Utils } from "@arkecosystem/crypto";
+
+import * as support from "../__support__";
+import { NFTExchangeTransactionFactory } from "../__support__/transaction-factory";
+
+let app: Contracts.Kernel.Application;
+beforeAll(async () => (app = await support.setUp()));
+afterAll(async () => await support.tearDown());
+
+describe("NFT Bid Cancel functional tests - with VendorField", () => {
+    it("should broadcast, accept and forge it [Signed with 1 Passphrase]", async () => {
+        // Register collection
+        const nftRegisteredCollection = NFTExchangeTransactionFactory.initialize(app)
+            .NFTRegisterCollection({
+                name: "Nascar Hero Cards",
+                description: "Nascar Hero Cards collection",
+                maximumSupply: 100,
+                jsonSchema: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["ipfsHashImageFront", "issuedDate", "issuedLocation", "signed"],
+                    properties: {
+                        ipfsHashImageFront: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        ipfsHashImageBack: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        issuedDate: {
+                            format: "date",
+                        },
+                        issuedLocation: {
+                            type: "string",
+                            maxLength: 255,
+                            minLength: 1,
+                        },
+                        signed: {
+                            type: "boolean",
+                        },
+                        tags: {
+                            type: "array",
+                            maxItems: 12,
+                            minItems: 1,
+                            additionalItems: false,
+                            uniqueItems: true,
+                            items: {
+                                type: "string",
+                            },
+                        },
+                    },
+                },
+            })
+            .withVendorField("VendorField test -> [NFTRegisterCollection]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftRegisteredCollection).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftRegisteredCollection.id).toBeForged();
+
+        // Create token
+        const nftCreate = NFTExchangeTransactionFactory.initialize(app)
+            .NFTCreate({
+                collectionId: nftRegisteredCollection.id!,
+                attributes: {
+                    ipfsHashImageFront: "QmavUFtLyRbUEEFLrmDTyRY5sLMh8UnQxWEenx2tuvzSE6",
+                    ipfsHashImageBack: "QmdGCntrw9yabGJAU1nG3H38yQ2GLsphg3jwaxSGbXEj61",
+                    issuedDate: "2020-09-25",
+                    issuedLocation: "Mooresville , North Carolina",
+                    signed: true,
+                },
+            })
+            .withVendorField("VendorField test -> [NFTCreate]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftCreate).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftCreate.id).toBeForged();
+
+        // Create auction
+        const nftAuction = NFTExchangeTransactionFactory.initialize(app)
+            .NFTAuction({
+                expiration: {
+                    blockHeight: 30,
+                },
+                startAmount: Utils.BigNumber.make("1"),
+                nftIds: [nftCreate.id!],
+            })
+            .withVendorField("VendorField test -> [NFTAuction]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftAuction).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftAuction.id).toBeForged();
+
+        // Create bid
+        const nftBid = NFTExchangeTransactionFactory.initialize(app)
+            .NFTBid({
+                auctionId: nftAuction.id!,
+                bidAmount: Utils.BigNumber.make("2"),
+            })
+            .withVendorField("VendorField test -> [NFTBid]")
+            .withPassphrase(passphrases[1]!)
+            .createOne();
+
+        await expect(nftBid).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftBid.id).toBeForged();
+
+        // Cancel bid
+        const nftCancelBid = NFTExchangeTransactionFactory.initialize(app)
+            .NFTBidCancel({
+                bidId: nftBid.id!,
+            })
+            .withVendorField("VendorField test -> [NFTBidCancel]")
+            .withPassphrase(passphrases[1]!)
+            .createOne();
+
+        await expect(nftCancelBid).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftCancelBid.id).toBeForged();
+    });
+});

--- a/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/nft-bid/vendor-field.test.ts
+++ b/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/nft-bid/vendor-field.test.ts
@@ -1,0 +1,120 @@
+import "@arkecosystem/core-test-framework/dist/matchers";
+
+import { Contracts } from "@arkecosystem/core-kernel";
+import { passphrases, snoozeForBlock } from "@arkecosystem/core-test-framework";
+import { Utils } from "@arkecosystem/crypto";
+
+import * as support from "../__support__";
+import { NFTExchangeTransactionFactory } from "../__support__/transaction-factory";
+
+let app: Contracts.Kernel.Application;
+beforeAll(async () => (app = await support.setUp()));
+afterAll(async () => await support.tearDown());
+
+describe("NFT Bid functional tests - with VendorField", () => {
+    it("should broadcast, accept and forge it [Signed with 1 Passphrase]", async () => {
+        // Register collection
+        const nftRegisteredCollection = NFTExchangeTransactionFactory.initialize(app)
+            .NFTRegisterCollection({
+                name: "Nascar Hero Cards",
+                description: "Nascar Hero Cards collection",
+                maximumSupply: 100,
+                jsonSchema: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["ipfsHashImageFront", "issuedDate", "issuedLocation", "signed"],
+                    properties: {
+                        ipfsHashImageFront: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        ipfsHashImageBack: {
+                            type: "string",
+                            maxLength: 120,
+                            minLength: 1,
+                        },
+                        issuedDate: {
+                            format: "date",
+                        },
+                        issuedLocation: {
+                            type: "string",
+                            maxLength: 255,
+                            minLength: 1,
+                        },
+                        signed: {
+                            type: "boolean",
+                        },
+                        tags: {
+                            type: "array",
+                            maxItems: 12,
+                            minItems: 1,
+                            additionalItems: false,
+                            uniqueItems: true,
+                            items: {
+                                type: "string",
+                            },
+                        },
+                    },
+                },
+            })
+            .withVendorField("VendorField test -> [NFTRegisterCollection]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftRegisteredCollection).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftRegisteredCollection.id).toBeForged();
+
+        // Create token
+        const nftCreate = NFTExchangeTransactionFactory.initialize(app)
+            .NFTCreate({
+                collectionId: nftRegisteredCollection.id!,
+                attributes: {
+                    ipfsHashImageFront: "QmavUFtLyRbUEEFLrmDTyRY5sLMh8UnQxWEenx2tuvzSE6",
+                    ipfsHashImageBack: "QmdGCntrw9yabGJAU1nG3H38yQ2GLsphg3jwaxSGbXEj61",
+                    issuedDate: "2020-09-25",
+                    issuedLocation: "Mooresville , North Carolina",
+                    signed: true,
+                },
+            })
+            .withVendorField("VendorField test -> [NFTCreate]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftCreate).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftCreate.id).toBeForged();
+
+        // Create auction
+        const nftAuction = NFTExchangeTransactionFactory.initialize(app)
+            .NFTAuction({
+                expiration: {
+                    blockHeight: 30,
+                },
+                startAmount: Utils.BigNumber.make("1"),
+                nftIds: [nftCreate.id!],
+            })
+            .withVendorField("VendorField test -> [NFTAuction]")
+            .withPassphrase(passphrases[0]!)
+            .createOne();
+
+        await expect(nftAuction).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftAuction.id).toBeForged();
+
+        // Create bid
+        const nftBid = NFTExchangeTransactionFactory.initialize(app)
+            .NFTBid({
+                auctionId: nftAuction.id!,
+                bidAmount: Utils.BigNumber.make("2"),
+            })
+            .withVendorField("VendorField test -> [NFTBid]")
+            .withPassphrase(passphrases[1]!)
+            .createOne();
+
+        await expect(nftBid).toBeAccepted();
+        await snoozeForBlock(1);
+        await expect(nftBid.id).toBeForged();
+    });
+});


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Fixed building of transactions with vendorField for nft-base.
Added missing vendorField functionality in nft-exchange.

### What changes are being made?
- Added vendorField property in `getStruct`
- Adjusted `transaction-forging ` setup
- Added vendorField specific functional tests
- Added specific GitHub Actions for this type of tests
- Added missing vendorField functionality in net-exchange

### Why are these changes necessary?
We decided that we will support vendorField in this custom transactions, so we set `setVendorField to true`.
We forgot to set vendorField property in `getStruct` method.
Also we decided to make vendorField possible in nft-exchange.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

